### PR TITLE
Support pagination

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": "^7.2.5",
+        "illuminate/pagination": "^6.0|^7.0",
         "illuminate/support": "^6.0|^7.0"
     },
     "require-dev": {

--- a/src/FlexiblePresenter.php
+++ b/src/FlexiblePresenter.php
@@ -131,14 +131,14 @@ abstract class FlexiblePresenter implements FlexiblePresenterContract, Arrayable
 
     public function get(): ?array
     {
-        if (is_null($this->resource) && is_null($this->collection) && is_null($this->paginationCollection)) {
+        if ($this->noResourceSpecified()) {
             return null;
         }
 
         if ($this->collection) {
             return $this->buildCollection();
         } elseif ($this->paginationCollection) {
-            return $this->buildpaginationCollection();
+            return $this->buildPaginationCollection();
         }
 
         $this->validateKeys();
@@ -176,10 +176,17 @@ abstract class FlexiblePresenter implements FlexiblePresenterContract, Arrayable
     public function whenLoaded(string $relationship)
     {
         if (! $this->resource->relationLoaded($relationship)) {
-            return;
+            return null;
         }
 
         return $this->resource->{$relationship};
+    }
+
+    protected function noResourceSpecified()
+    {
+        return is_null($this->resource)
+            && is_null($this->collection)
+            && is_null($this->paginationCollection);
     }
 
     protected function buildCollection(): array

--- a/src/FlexiblePresenter.php
+++ b/src/FlexiblePresenter.php
@@ -2,16 +2,16 @@
 
 namespace AdditionApps\FlexiblePresenter;
 
-use Closure;
-use Illuminate\Support\Str;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\App;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Pagination\AbstractPaginator;
-use Illuminate\Http\Resources\DelegatesToResource;
+use AdditionApps\FlexiblePresenter\Contracts\FlexiblePresenterContract;
 use AdditionApps\FlexiblePresenter\Exceptions\InvalidPresenterKeys;
 use AdditionApps\FlexiblePresenter\Exceptions\InvalidPresenterPreset;
-use AdditionApps\FlexiblePresenter\Contracts\FlexiblePresenterContract;
+use Closure;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Http\Resources\DelegatesToResource;
+use Illuminate\Pagination\AbstractPaginator;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Str;
 
 abstract class FlexiblePresenter implements FlexiblePresenterContract, Arrayable
 {
@@ -97,7 +97,7 @@ abstract class FlexiblePresenter implements FlexiblePresenterContract, Arrayable
 
     public function lazy($expression)
     {
-        return function () use ($expression) {
+        return function() use ($expression) {
             return $expression;
         };
     }
@@ -105,12 +105,12 @@ abstract class FlexiblePresenter implements FlexiblePresenterContract, Arrayable
     public function all(): array
     {
         return collect($this->values())
-            ->mapWithKeys(function ($value, $key) {
+            ->mapWithKeys(function($value, $key) {
                 return [
                     $key => ($value instanceof Closure) ? App::call($value) : $value,
                 ];
             })
-            ->mapWithKeys(function ($value, $key) {
+            ->mapWithKeys(function($value, $key) {
                 return [
                     $key => ($value instanceof Arrayable) ? $value->toArray() : $value,
                 ];
@@ -144,23 +144,23 @@ abstract class FlexiblePresenter implements FlexiblePresenterContract, Arrayable
         $this->validateKeys();
 
         return collect($this->values())
-            ->filter(function ($value, $key) {
+            ->filter(function($value, $key) {
                 return empty($this->only)
                     ? true
                     : in_array($key, $this->only);
             })
-            ->reject(function ($value, $key) {
+            ->reject(function($value, $key) {
                 return empty($this->except)
                     ? false
                     : in_array($key, $this->except);
             })
             ->merge($this->with)
-            ->mapWithKeys(function ($value, $key) {
+            ->mapWithKeys(function($value, $key) {
                 return [
                     $key => ($value instanceof Closure) ? App::call($value) : $value,
                 ];
             })
-            ->mapWithKeys(function ($value, $key) {
+            ->mapWithKeys(function($value, $key) {
                 return [
                     $key => ($value instanceof Arrayable) ? $value->toArray() : $value,
                 ];
@@ -175,7 +175,7 @@ abstract class FlexiblePresenter implements FlexiblePresenterContract, Arrayable
 
     public function whenLoaded(string $relationship)
     {
-        if (! $this->resource->relationLoaded($relationship)) {
+        if (!$this->resource->relationLoaded($relationship)) {
             return null;
         }
 
@@ -205,7 +205,7 @@ abstract class FlexiblePresenter implements FlexiblePresenterContract, Arrayable
 
     protected function mapCollectionResource(Collection $collection): Collection
     {
-        return $collection->map(function ($resource) {
+        return $collection->map(function($resource) {
             $presenter = new static($resource);
             $presenter->only = $this->only;
             $presenter->except = $this->except;

--- a/tests/FlexiblePresenterTest.php
+++ b/tests/FlexiblePresenterTest.php
@@ -2,16 +2,16 @@
 
 namespace AdditionApps\FlexiblePresenter\Tests;
 
+use AdditionApps\FlexiblePresenter\Exceptions\InvalidPresenterKeys;
+use AdditionApps\FlexiblePresenter\FlexiblePresenter;
+use AdditionApps\FlexiblePresenter\Tests\Support\Models\Comment;
+use AdditionApps\FlexiblePresenter\Tests\Support\Models\Post;
+use AdditionApps\FlexiblePresenter\Tests\Support\Presenters\CommentPresenter;
+use AdditionApps\FlexiblePresenter\Tests\Support\Presenters\PostPresenter;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Pagination\Paginator;
-use Illuminate\Pagination\LengthAwarePaginator;
-use AdditionApps\FlexiblePresenter\FlexiblePresenter;
-use AdditionApps\FlexiblePresenter\Tests\Support\Models\Post;
-use AdditionApps\FlexiblePresenter\Tests\Support\Models\Comment;
-use AdditionApps\FlexiblePresenter\Exceptions\InvalidPresenterKeys;
-use AdditionApps\FlexiblePresenter\Tests\Support\Presenters\PostPresenter;
-use AdditionApps\FlexiblePresenter\Tests\Support\Presenters\CommentPresenter;
 
 class FlexiblePresenterTest extends TestCase
 {
@@ -69,7 +69,7 @@ class FlexiblePresenterTest extends TestCase
         );
 
         $presenter = PostPresenter::collection($paginationCollection);
-        
+
         $this->assertInstanceOf(FlexiblePresenter::class, $presenter);
         $this->assertInstanceOf(Paginator::class, $presenter->paginationCollection);
         $this->assertCount(2, $presenter->paginationCollection->getCollection());
@@ -103,7 +103,7 @@ class FlexiblePresenterTest extends TestCase
         $post = $this->createPostAndComments();
 
         $return = PostPresenter::make($post)
-            ->with(function ($post) {
+            ->with(function($post) {
                 return ['new_key' => 'foo'];
             })
             ->get();
@@ -124,7 +124,7 @@ class FlexiblePresenterTest extends TestCase
         $post = $this->createPostAndComments();
 
         $return = PostPresenter::make($post)
-            ->with(function ($post) {
+            ->with(function($post) {
                 return ['published_at' => $post->published_at->toDayDateTimeString()];
             })
             ->get();
@@ -357,7 +357,7 @@ class FlexiblePresenterTest extends TestCase
     {
         $post = $this->createPostAndComments();
 
-        $return = PostPresenter::make($post)->only('title')->with(function ($post) {
+        $return = PostPresenter::make($post)->only('title')->with(function($post) {
             return [
                 'comments' => CommentPresenter::collection($post->comments)->only('id'),
             ];

--- a/tests/FlexiblePresenterTest.php
+++ b/tests/FlexiblePresenterTest.php
@@ -69,7 +69,7 @@ class FlexiblePresenterTest extends TestCase
         );
 
         $presenter = PostPresenter::collection($paginationCollection);
-
+        
         $this->assertInstanceOf(FlexiblePresenter::class, $presenter);
         $this->assertInstanceOf(Paginator::class, $presenter->paginationCollection);
         $this->assertCount(2, $presenter->paginationCollection->getCollection());


### PR DESCRIPTION
Added presentation support for `Illuminate\Pagination\Paginator` and `Illuminate\Pagination\LengthAwarePaginator`.

Use example:

```php
$posts = PostPresenter::collection(
    Post::paginate()
)->only('id', 'title')->get();

// Output:
// [
//     'current_page' => 1,
//     'data' => [
//         [
//             'id' => 1,
//             'title' => 'foo',
//         ],
//         [
//             'id' => 2,
//             'title' => 'foo',
//         ],
//     ],
//     'first_page_url' => '/?page=1',
//     'from' => 1,
//     'next_page_url' => null,
//     'path' => '/',
//     'per_page' => 2,
//     'prev_page_url' => null,
//     'to' => 2,
// ];
```

Custom Paginator can work normally as long as it extend `AbstractPaginator` class and implements `Arrayable` interface.