### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ class PostPresenter extends FlexiblePresenter
 }
 ```
 
-Once the presenter is defined, can return to Inertia view or any you want to using it:
+Once a presenter is defined, you are free to return it as part of an InertiaJS response or in any other context that you need the presented data:
 
 ```php
 class PostController extends Controller
@@ -248,7 +248,7 @@ PostPresenter::make($post)->preset('summary')->with(function () {
 });
 ```
 
-**Caveat: repeat call method**
+**Caveat: repeated method calls**
 
 Just bear in mind that if you use an API method in your preset method (for example `only`) and then chain another `only` method onto it when using your presenter, that the last call to `only` will be the one to take effect:
 
@@ -335,7 +335,7 @@ Once you've configured an instantiated presenter the way you want, you can get t
 PostPresenter::make($post)->only('id', 'title')->get();
 ```
 
-If you wish to return all the defined values in your presenter (without any configuration) then you can use the `all` method, It will ignore the values ​​defined by `only()`, `except()`, `with()`:
+If you wish to return all the defined values in your presenter (without any configuration) then you can use the `all` method:
 
 ```php
 PostPresenter::make($post)->all();

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ public function values()
 {
     return [
         'id' => $this->id,
-        'comment_count' => function(){
+        'comment_count' => function () {
             return $this->comments->count();
-        }
+        },
     ];
 }
 ```
@@ -77,7 +77,7 @@ If you are using PHP >= 7.4 you can make things a little more readable by using 
 
 ```php
 [
-    'comment_count' => fn() => $this->comments->count()
+    'comment_count' => fn() => $this->comments->count(),
 ];
 ```
 
@@ -92,9 +92,10 @@ public function values()
 {
     return [
         'id' => $this->id,
-        'comments' => function(){
-            return CommentPresenter::collection($this->comments)->except('body', 'updated_at');
-        }
+        'comments' => function () {
+            return CommentPresenter::collection($this->comments)
+                ->except('body', 'updated_at');
+        },
     ];
 }
 ```
@@ -114,7 +115,7 @@ public function values()
 {
     return [
         'id' => $this->resource['id'],
-        'title' => $this->resource['title']
+        'title' => $this->resource['title'],
     ];
 }
 ```
@@ -193,7 +194,7 @@ The `with` method accepts a closure that takes as it's only argument the resourc
 PostPresenter::make($post)->with(function($post){
     return [
         'title' => strtoupper($post->title),
-        'new_key' => 'Some value'
+        'new_key' => 'Some value',
     ];
 });
 ```
@@ -218,9 +219,9 @@ public function presetSummary()
 Your preset method should use the same presenter API methods above to build up a set of values.  Note that all of these API methods can be chained, so, for example, you can modify a preset on the fly if you wish:
 
 ```php
-PostPresenter::make($post)->preset('summary')->with(function(){
+PostPresenter::make($post)->preset('summary')->with(function () {
     return [
-        'comment_count' => $post->comments->count()
+        'comment_count' => $post->comments->count(),
     ];
 });
 ```
@@ -262,19 +263,19 @@ If you are presenting a paginated collection of resources you may want to add so
     'prev_page_url' => null,
     'to' => 2,
     'links' => [
-        'create' => 'some-url'
-    ]
+        'create' => 'some-url',
+    ],
 ];
 ```
 
 Using appends you are free to add (or overwrite) the keys in this array:
 
 ```php
-$return = PostPresenter::collection($paginatedCollection)
+$posts = PostPresenter::collection($paginatedCollection)
     ->only('id')
     ->appends([
         'foo' => 'bar',
-        'links' => [ 'store' => 'some-other-url' ]
+        'links' => ['store' => 'some-other-url'],
     ])
     ->get();
 ```
@@ -297,8 +298,8 @@ This will now output:
     'foo' => 'bar',
     'links' => [
         'create' => 'some-url',
-        'store' => 'some-other-url'
-    ]
+        'store' => 'some-other-url',
+    ],
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,23 +62,23 @@ The only required method in a presenter class is `values()` which should return 
 You can also define fields that are computed in more complex ways - for example you may want to add a presenter value that is derived from some other data like a relationship.  In these situations it can be handy to wrap your value definition in a closure.  Doing so will ensure that the value is only computed if it's actually asked for:
 
 ```php
-    public function values()
-    {
-        return [
-            'id' => $this->id,
-            'comment_count' => function(){
-                return $this->comments->count();
-            }
-        ];
-    }
+public function values()
+{
+    return [
+        'id' => $this->id,
+        'comment_count' => function(){
+            return $this->comments->count();
+        }
+    ];
+}
 ```
 
 If you are using PHP >= 7.4 you can make things a little more readable by using the new short closure syntax:
 
 ```php
-    [
-        'comment_count' => fn() => $this->comments->count()
-    ];
+[
+    'comment_count' => fn() => $this->comments->count()
+];
 ```
 
 Now if we call `PostPresenter::make($post)->only(['id'])` the `comment_count` value will not be evaluated meaning we do not need to worry about ensuring that relationship is loaded on the model.
@@ -88,15 +88,15 @@ Now if we call `PostPresenter::make($post)->only(['id'])` the `comment_count` va
 If necessary you can define a value that returns another presenter.  This is handy if you want to only return certain values for a relation of the model you're working with:
 
 ```php
-    public function values()
-    {
-        return [
-            'id' => $this->id,
-            'comments' => function(){
-                return CommentPresenter::collection($this->comments)->except('body', 'updated_at');
-            }
-        ];
-    }
+public function values()
+{
+    return [
+        'id' => $this->id,
+        'comments' => function(){
+            return CommentPresenter::collection($this->comments)->except('body', 'updated_at');
+        }
+    ];
+}
 ```
 
 Note that in the example above we're using lazy evaluation so that we don't have to worry about the `comments` relationship being loaded on the `Post` model.  If you know this relationship will always be loaded you could dispense with the closure.
@@ -110,13 +110,13 @@ Once you have defined your presenter class you can use it in your controller (or
 The `make` method accepts a single resource as a parameter.  In the majority of cases this will be an Eloquent model but there is no requirement that you pass a model specifically.  For instance you could pass a some other object or even an associative array and then within the `values()` method in your presenter use it like so:
 
 ```php
-    public function values()
-    {
-        return [
-            'id' => $this->resource['id'],
-            'title' => $this->resource['title']
-        ];
-    }
+public function values()
+{
+    return [
+        'id' => $this->resource['id'],
+        'title' => $this->resource['title']
+    ];
+}
 ```
 
 #### `PostPresenter::collection($posts)`
@@ -165,10 +165,10 @@ The `new` method accepts no parameters.  This method is useful for when you have
 If one of your presenters has a key should return a presented relation as a value, you can use the convenience method `whenLoaded` to conditionally include the relation:
 
 ```php
-    // In PostPresenter
-   return [
-        'comments' => CommentPresenter::collection($this->whenLoaded('comments')),
-   ];
+// In PostPresenter
+return [
+    'comments' => CommentPresenter::collection($this->whenLoaded('comments')),
+];
 ```
 
 In the above example the `comments` key will be a collection of presented comments if the relation is loaded and `null` if they are not.
@@ -190,12 +190,12 @@ The `except` method accepts keys that you want to exclude from your presenter in
 The `with` method accepts a closure that takes as it's only argument the resource that is being transformed.  You can use the `with` method to overwrite the values of existing keys or to add entirely new keys to your presenter on-the-fly.  It should return an array with the keys you want to overwrite/add along with their values.
 
 ```php
-    PostPresenter::make($post)->with(function($post){
-        return [
-            'title' => strtoupper($post->title),
-            'new_key' => 'Some value'
-        ];
-    });
+PostPresenter::make($post)->with(function($post){
+    return [
+        'title' => strtoupper($post->title),
+        'new_key' => 'Some value'
+    ];
+});
 ```
 
 #### `preset()`
@@ -203,26 +203,26 @@ The `with` method accepts a closure that takes as it's only argument the resourc
 You may find that there are combinations of presenter values that you use repeatedly throughout your application.  If so, rather than explicitly asking for those particular fields each time you can add a 'preset' to your presenter class and ask for that preset instead:
 
 ```php
-    PostPresenter::make($post)->preset('summary');
+PostPresenter::make($post)->preset('summary');
 ```
 
 Within your presenter class you should create a method with the name of your preset, prefixed with 'preset'.  Given the example above we would create a method like this:
 
 ```php
-    public function presetSummary()
-    {
-        return $this->only('title', 'published_at');
-    }
+public function presetSummary()
+{
+    return $this->only('title', 'published_at');
+}
 ```
 
 Your preset method should use the same presenter API methods above to build up a set of values.  Note that all of these API methods can be chained, so, for example, you can modify a preset on the fly if you wish:
 
 ```php
-    PostPresenter::make($post)->preset('summary')->with(function(){
-        return [
-            'comment_count' => $post->comments->count()
-        ];
-    });
+PostPresenter::make($post)->preset('summary')->with(function(){
+    return [
+        'comment_count' => $post->comments->count()
+    ];
+});
 ```
 
 #### Caveat
@@ -230,18 +230,18 @@ Your preset method should use the same presenter API methods above to build up a
 Just bear in mind that if you use an API method in your preset method (for example `only`) and then chain another `only` method onto it when using your presenter, that the last call to `only` will be the one to take effect:
 
 ```php
-    // In PostPresenter...
-    public function presetSummary()
-    {
-        return $this->only('title', 'body');
-    }
+// In PostPresenter...
+public function presetSummary()
+{
+    return $this->only('title', 'body');
+}
 
-    // In Controller...
-    PostPresenter::make($post)->preset('summary');
-    // Will return ['title' => 'foo', 'body' => 'bar']
+// In Controller...
+PostPresenter::make($post)->preset('summary');
+// Will return ['title' => 'foo', 'body' => 'bar']
 
-    PostPresenter::make($post)->preset('summary')->only('id');
-    // Will return ['id' => 1]
+PostPresenter::make($post)->preset('summary')->only('id');
+// Will return ['id' => 1]
 ```
 
 #### `appends()`
@@ -309,7 +309,7 @@ Note that appended values are merged recursively (as in the `links` example abov
 Once you've configured an instantiated presenter the way you want, you can get the values as an array by chaining the `get` method:
 
 ```php
-    PostPresenter::make($post)->only('id', 'title')->get();
+PostPresenter::make($post)->only('id', 'title')->get();
 ```
 
 If you wish to return all the defined values in your presenter (without any configuration) then you can use the `all` method.

--- a/README.md
+++ b/README.md
@@ -335,7 +335,11 @@ Once you've configured an instantiated presenter the way you want, you can get t
 PostPresenter::make($post)->only('id', 'title')->get();
 ```
 
-If you wish to return all the defined values in your presenter (without any configuration) then you can use the `all` method.
+If you wish to return all the defined values in your presenter (without any configuration) then you can use the `all` method, It will ignore the values ​​defined by `only()`, `except()`, `with()`:
+
+```php
+PostPresenter::make($post)->all();
+```
 
 Finally, all presenters implement the `Arrayable` interface so you are passing your presenter to a context that looks for this contract, your presenter values will be automatically converted to an array without you having to use `get()`.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Easily define just the right data for your InertiaJS views (or anywhere else you want to, uh, flexibly present).**
 
-This package allows you to define presenter classes that take logic involved in getting data ready for your view layer out of your controller.  It also provides an expressive, fluent API that allows you to modify and reuse your presenters on the fly so that you're only ever providing relevant data.  
+This package allows you to define presenter classes that take logic involved in getting data ready for your view layer out of your controller.  It also provides an expressive, fluent API that allows you to modify and reuse your presenters on the fly so that you're only ever providing relevant data.
 
 This package was built specifically for use with [Inertia](https://inertiajs.com) (:heart_eyes:) because we didn't like the fact we were sending more data than we needed to our views.  That said, you're free to use it however you please - it's not dependant on Inertia in any way.
 
@@ -55,7 +55,7 @@ This presenter will have the App\Blog\Presenters namespace and will be saved in 
 
 ### Defining values
 
-The only required method in a presenter class is `values()` which should return an array with **all** the possible fields you might want to display in a view.  These could simply be values directly on your model (as in the example above).  Note that you can access model properties directly from the `$this` variable, just as you can when using [Laravel API Resources](https://laravel.com/docs/6.x/eloquent-resources). 
+The only required method in a presenter class is `values()` which should return an array with **all** the possible fields you might want to display in a view.  These could simply be values directly on your model (as in the example above).  Note that you can access model properties directly from the `$this` variable, just as you can when using [Laravel API Resources](https://laravel.com/docs/6.x/eloquent-resources).
 
 ### Lazy evaluation
 
@@ -81,7 +81,7 @@ If you are using PHP >= 7.4 you can make things a little more readable by using 
     ];
 ```
 
-Now if we call `PostPresenter::make($post)->only(['id'])` the `comment_count` value will not be evaluated meaning we do not need to worry about ensuring that relationship is loaded on the model.   
+Now if we call `PostPresenter::make($post)->only(['id'])` the `comment_count` value will not be evaluated meaning we do not need to worry about ensuring that relationship is loaded on the model.
 
 ### Nested presenters
 
@@ -123,9 +123,9 @@ The `make` method accepts a single resource as a parameter.  In the majority of 
 
 The `collection` method accepts an Eloquent collection (or a plain array) of resources as a parameter.  Each member of the collection will be transformed by the presenter as specified.  Again the members of that collection can be Eloquent models, other objects or arrays.
 
-As well as passing an Eloquent collection or array, you can also pass a Laravel paginator instance.  You are free to pass an instance of either `Illuminate\Pagination\Paginator` or `Illuminate\Pagination\LengthAwarePaginator`. You can also pass a custom paginator as long as it extends the `Illuminate\Pagination\AbstractPaginator` class and implements the `Illuminate\Contracts\Support\Arrayable` interface.  
+As well as passing an Eloquent collection or array, you can also pass a Laravel paginator instance.  You are free to pass an instance of either `Illuminate\Pagination\Paginator` or `Illuminate\Pagination\LengthAwarePaginator`. You can also pass a custom paginator as long as it extends the `Illuminate\Pagination\AbstractPaginator` class and implements the `Illuminate\Contracts\Support\Arrayable` interface.
 
-Here's an example of a presenter used with an eloquent collection using simple pagination: 
+Here's an example of a presenter used with an eloquent collection using simple pagination:
 
 ```php
 $posts = PostPresenter::collection(Post::simplePaginate())
@@ -211,7 +211,7 @@ Within your presenter class you should create a method with the name of your pre
 ```php
     public function presetSummary()
     {
-        return $this->only('title', 'published_at');  
+        return $this->only('title', 'published_at');
     }
 ```
 
@@ -235,7 +235,7 @@ Just bear in mind that if you use an API method in your preset method (for examp
     {
         return $this->only('title', 'body');
     }
-    
+
     // In Controller...
     PostPresenter::make($post)->preset('summary');
     // Will return ['title' => 'foo', 'body' => 'bar']

--- a/README.md
+++ b/README.md
@@ -136,7 +136,15 @@ public function values()
 
 #### `PostPresenter::collection($posts)`
 
-The `collection` method accepts an Eloquent collection (or a plain array) of resources as a parameter.  Each member of the collection will be transformed by the presenter as specified.  Again the members of that collection can be Eloquent models, other objects or arrays.
+The `collection` method accepts an Eloquent collection (or a plain array) of resources as a parameter.  Each member of the collection will be transformed by the presenter as specified.  Again the members of that collection can be Eloquent models, other objects or arrays:
+
+```php
+$posts = PostPresenter::collection(Post::all())
+    ->only('id', 'title')
+    ->get();
+```
+
+**Using Pagination**
 
 As well as passing an Eloquent collection or array, you can also pass a Laravel paginator instance.  You are free to pass an instance of either `Illuminate\Pagination\Paginator` or `Illuminate\Pagination\LengthAwarePaginator`. You can also pass a custom paginator as long as it extends the `Illuminate\Pagination\AbstractPaginator` class and implements the `Illuminate\Contracts\Support\Arrayable` interface.
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ PostPresenter::make($post)->preset('summary')->with(function () {
 });
 ```
 
-#### Caveat
+**Caveat: repeat call method**
 
 Just bear in mind that if you use an API method in your preset method (for example `only`) and then chain another `only` method onto it when using your presenter, that the last call to `only` will be the one to take effect:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,28 @@ composer require additionapps/flexible-presenter
 
 ## Usage
 
-A presenter is a class in which you can define all the possible fields that you might want to expose to your Inertia views.  When you call the class from a controller method you can use methods such as `only` or `except` to define which of these fields you want to expose in that given context.  More on the API in a bit, for now, here's a simple presenter class:
+The package includes an artisan command to create a new presenter:
+
+```bash
+php artisan make:presenter PostsPresenter
+```
+
+This presenter will have the `App\Presenters` namespace and will be saved in `app/Presenters`.
+
+You can also specify a custom namespace, say, `App\Blog`
+
+```bash
+php artisan make:presenter "Blog/Presenters/PostsPresenter"
+```
+This presenter will have the `App\Blog\Presenters` namespace and will be saved in `app/Blog/Presenters`.
+
+### Defining values
+
+A presenter is a class in which you can define all the possible fields that you might want to expose to your Inertia views.  When you call the class from a controller method you can use methods such as `only` or `except` to define which of these fields you want to expose in that given context. More on the API in a bit.
+
+The only required method in a presenter class is `values()` which should return an array with **all** the possible fields you might want to display in a view.  These could simply be values directly on your model.  Note that you can access model properties directly from the `$this` variable, just as you can when using [Laravel API Resources](https://laravel.com/docs/eloquent-resources).
+
+For now, here's a simple presenter class:
 
 ```php
 class PostPresenter extends FlexiblePresenter
@@ -36,26 +57,19 @@ class PostPresenter extends FlexiblePresenter
 }
 ```
 
-### Making a new presenter
+Once the presenter is defined, can return to Inertia view or any you want to using it:
 
-The package includes an artisan command to create a new presenter:
-
-```bash
-php artisan make:presenter PostsPresenter
+```php
+class PostController extends Controller
+{
+    public function show(Post $post)
+    {
+        return Inertia::render('Posts/Show', [
+            'post' => PostPresenter::make($post)->get(),
+        ]);
+    }
+}
 ```
-
-This presenter will have the `App\Presenters` namespace and will be saved in `app/Presenters`.
-
-You can also specify a custom namespace, say, App\Blog
-
-```bash
-php artisan make:presenter "Blog/Presenters/PostsPresenter"
-```
-This presenter will have the App\Blog\Presenters namespace and will be saved in app/Blog/Presenters.
-
-### Defining values
-
-The only required method in a presenter class is `values()` which should return an array with **all** the possible fields you might want to display in a view.  These could simply be values directly on your model (as in the example above).  Note that you can access model properties directly from the `$this` variable, just as you can when using [Laravel API Resources](https://laravel.com/docs/6.x/eloquent-resources).
 
 ### Lazy evaluation
 


### PR DESCRIPTION
### README change list:

* Remove more white space
* Remove all code indent
* Update coding style and variable name
* Change `Caveat` part name to `Caveat: repeat call method`
* **Improve `Usage` part, make it easier to get started**
* Add `PostPresenter::collection($posts)` example
* Improve `Returning values` part

The `Usage` part is a relatively big change: Move `make:presenter` part to the top, followed by `Defining values`, and finally I added the example of `Inertia render`. I think this change makes it easier for users to get started.

This PR is improving the content of the README. There are many changes. @fourstacks can see the changes of each commit. If you don’t want to use a certain commit, you can revert it or modify it.

---

My mother tongue is not English, and some words or grammar may need to be improved. If this PR causes you trouble, I will close it. 😓
