### PR TITLE
Update presenter stub

### DIFF
--- a/stubs/DummyFlexiblePresenter.stub
+++ b/stubs/DummyFlexiblePresenter.stub
@@ -9,7 +9,7 @@ class DummyClass extends FlexiblePresenter
     public function values(): array
     {
         return [
-            // 'id' => $this->resource->id
+            // 'id' => $this->id,
         ];
     }
 }


### PR DESCRIPTION
Update the stub to be consistent with the README:

*README example*:
```php
class PostPresenter extends FlexiblePresenter
{
    public function values()
    {
        return [
            'id' => $this->id,
            'title' => $this->title,
            'body' => $this->body,
        ];
    }
}
```