### PR TITLE
Add chain with() feature

### DIFF
--- a/src/FlexiblePresenter.php
+++ b/src/FlexiblePresenter.php
@@ -38,8 +38,8 @@ abstract class FlexiblePresenter implements FlexiblePresenterContract, Arrayable
     /** @var array */
     public $appends = [];
 
-    /** @var callable|null */
-    protected $withCallback;
+    /** @var array|callable[] */
+    protected $withCallback = [];
 
     /** @var bool */
     protected $withoutResource = false;
@@ -81,9 +81,9 @@ abstract class FlexiblePresenter implements FlexiblePresenterContract, Arrayable
     public function with(callable $callback): self
     {
         if ($this->resource) {
-            $this->with = $callback($this->resource);
+            $this->with = array_merge($this->with, $callback($this->resource));
         } else {
-            $this->withCallback = $callback;
+            $this->withCallback[] = $callback;
         }
 
         return $this;
@@ -229,8 +229,10 @@ abstract class FlexiblePresenter implements FlexiblePresenterContract, Arrayable
             $presenter = new static($resource);
             $presenter->only = $this->only;
             $presenter->except = $this->except;
-            if ($this->withCallback) {
-                $presenter->with($this->withCallback);
+            if (count($this->withCallback)) {
+                foreach ($this->withCallback as $callable) {
+                    $presenter->with($callable);
+                }
             }
 
             return $presenter->get();

--- a/tests/FlexiblePresenterTest.php
+++ b/tests/FlexiblePresenterTest.php
@@ -125,6 +125,34 @@ class FlexiblePresenterTest extends TestCase
     }
 
     /** @test */
+    public function can_use_chain_with_method_when_presenting_resource()
+    {
+        $post = $this->createPostAndComments();
+
+        $return = PostPresenter::make($post)
+            ->with(function ($post) {
+                return [
+                    'new_key_1' => 'foo',
+                    'new_key_2' => 'bar',
+                ];
+            })
+            ->with(function ($post) {
+                return ['new_key_2' => 'baz'];
+            })
+            ->get();
+
+        $this->assertEquals([
+            'id' => $post->id,
+            'title' => $post->title,
+            'body' => $post->body,
+            'published_at' => $post->published_at->toDateString(),
+            'comment_count' => 3,
+            'new_key_1' => 'foo',
+            'new_key_2' => 'baz',
+        ], $return);
+    }
+
+    /** @test */
     public function keys_are_overwritten_using_with_method_when_presenting_resource()
     {
         $post = $this->createPostAndComments();
@@ -141,6 +169,33 @@ class FlexiblePresenterTest extends TestCase
             'body' => $post->body,
             'published_at' => $post->published_at->toDayDateTimeString(),
             'comment_count' => 3,
+        ], $return);
+    }
+
+    /** @test */
+    public function can_chain_with_method()
+    {
+        $post = $this->createPostAndComments();
+
+        $return = CommentPresenter::collection($post->comments)
+            ->only('id')
+            ->with(function ($comment) {
+                return [
+                    'new_key_1' => 'foo',
+                    'new_key_2' => 'bar',
+                ];
+            })
+            ->with(function ($comment) {
+                return [
+                    'new_key_2' => 'baz',
+                ];
+            })
+            ->get();
+
+        $this->assertEquals([
+            ['id' => 1, 'new_key_1' => 'foo', 'new_key_2' => 'baz'],
+            ['id' => 2, 'new_key_1' => 'foo', 'new_key_2' => 'baz'],
+            ['id' => 3, 'new_key_1' => 'foo', 'new_key_2' => 'baz'],
         ], $return);
     }
 


### PR DESCRIPTION
This PR add can chain use `with` method feature:

```php
PostPresenter::make($post)
    ->with(function ($post) {
        return [
            'new_key_1' => 'foo',
            'new_key_2' => 'bar',
        ];
    })
    ->with(function ($post) {
        return [
            'new_key_2' => 'baz',
        ];
    })
    ->get();

// Return:
// [
//     'id' => $post->id,
//     'title' => $post->title,
//     'body' => $post->body,
//     'new_key_1' => 'foo',
//     'new_key_2' => 'baz',
// ]
```