### PR TITLE
add support for PHP 8.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 7.3]
+        php: [8.0, 7.4, 7.3]
         laravel: [6.*, 7.*, 8.*]
         dependency-version: [prefer-stable]
         os: [ubuntu-latest]

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/pagination": "^6.0|^7.0|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "fzaninotto/faker": "^1.8",
+        "fakerphp/faker": "^1.12",
         "laravel/legacy-factories": "^1.0",
         "orchestra/testbench": "^6.0",
         "phpunit/phpunit": "~9.0"


### PR DESCRIPTION
* Add support for PHP 8.0
* Replace `fzaninotto/faker` since it has been archived and doesn't support PHP 8.0 and replace it with `fakerphp/faker` [Changes coming to PHP Faker](https://laravel-news.com/changes-coming-to-php-faker)
